### PR TITLE
docfix: 'library', not 'repository'

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -24,7 +24,7 @@ To install on IBM i, you need to clone this git repository onto an IBM i. You ca
 
 Once the repo sources are in the IFS, then you can use GNU Make to build the SDK. GNU Make, `gmake`, is available in yum. Read more on the [IBM i OSS](https://ibmi-oss-docs.readthedocs.io/en/latest/yum/README.html#installation) docs.
 
-Everything will get built into the `dbsdk_v1` repository.
+Everything will get built into the `dbsdk_v1` library.
 
 ```sh
 cd /where/you/extracted/the/repo


### PR DESCRIPTION
Objects are built into an OFS library, not a 'repository'