### PR TITLE
fix: Adds function openai_compatible_chat_generate() for Gemini

### DIFF
--- a/docs/src/content/docs/openai/examples.mdx
+++ b/docs/src/content/docs/openai/examples.mdx
@@ -272,3 +272,74 @@ SELECT dbsdk_v1.openai_compatible_generate(
 ```
 
 These examples demonstrate the versatility of the OpenAI-compatible endpoints for various use cases in your IBM i applications.
+
+## Using Google Gemini
+
+Gemini requires the `openai_compatible_chat_generate` function because:
+- The standard `openai_compatible_generate` function targets the legacy `/completions` endpoint, which Gemini does not implement.
+- Gemini's OpenAI-compatibility layer rejects requests that contain unsupported fields (`n`, `top_p`, `presence_penalty`, `frequency_penalty`) with HTTP 400, even when those fields carry standard OpenAI default values. `openai_compatible_chat_generate` only sends fields that are explicitly present in the `options` argument.
+
+### Configuration
+
+Gemini's OpenAI-compatible base path is `/v1beta/openai` — this is different from the
+standard `/v1` used by most other providers.
+
+```sql
+-- Configure connection for Gemini
+CALL dbsdk_v1.openai_compatible_setserverforjob('generativelanguage.googleapis.com');
+CALL dbsdk_v1.openai_compatible_setportforjob(443);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob('https');
+CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1beta/openai');
+CALL dbsdk_v1.openai_compatible_setapikeyforjob('your-gemini-api-key');
+CALL dbsdk_v1.openai_compatible_setmodelforjob('gemini-3.6-flash');
+```
+
+### Simple Prompt
+
+```sql
+-- Use openai_compatible_chat_generate — NOT openai_compatible_generate — for Gemini
+SELECT dbsdk_v1.openai_compatible_chat_generate(
+  'What is Db2 for i?'
+) FROM sysibm.sysdummy1;
+```
+
+### With Optional Parameters
+
+Only include parameters you explicitly want to control. Unspecified parameters are
+omitted from the request body entirely, keeping the request compatible with Gemini's
+strict field validation.
+
+```sql
+SELECT dbsdk_v1.openai_compatible_chat_generate(
+  'Explain the difference between a primary key and a unique constraint in SQL',
+  '{
+    "model_id": "gemini-3.6-flash",
+    "max_tokens": 300,
+    "temperature": 0.4
+  }'
+) FROM sysibm.sysdummy1;
+```
+
+### Generating and Storing Gemini Responses
+
+```sql
+-- Create a table for storing responses
+CREATE TABLE mylib.gemini_responses (
+  id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  prompt VARCHAR(1000),
+  response CLOB(2G),
+  generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Generate a response and store it
+INSERT INTO mylib.gemini_responses (prompt, response)
+SELECT
+  'List three best practices for IBM i database design',
+  dbsdk_v1.openai_compatible_chat_generate(
+    'List three best practices for IBM i database design',
+    '{"max_tokens": 400, "temperature": 0.5}'
+  )
+FROM sysibm.sysdummy1;
+
+SELECT * FROM mylib.gemini_responses;
+```

--- a/docs/src/content/docs/openai/usage.mdx
+++ b/docs/src/content/docs/openai/usage.mdx
@@ -145,9 +145,91 @@ SELECT dbsdk_v1.openai_compatible_generate_json(
 
 The `generate_json` function returns the complete API response as a JSON object, allowing you to access not only the generated content but also metadata such as token usage statistics.
 
+## Chat Completions (Gemini and strict endpoints)
+
+### Why `openai_compatible_generate` does not work with Gemini
+
+`openai_compatible_generate` (and `openai_compatible_generate_json`) use the **legacy
+text-completion endpoint** — they POST to `/completions` with a top-level `"prompt"`
+field. This is incompatible with Gemini for two reasons:
+
+1. **Wrong endpoint.** Gemini only implements the chat-completion API (`/chat/completions`). It does not expose `/completions` at all.
+2. **Strict field rejection.** Even when targeting `/chat/completions`, Gemini returns HTTP 400 if the request body contains any field it does not recognise — including `n`, `top_p`, `presence_penalty`, and `frequency_penalty` — even when those fields carry standard OpenAI default values.
+
+Use `openai_compatible_chat_generate` for Gemini and any other endpoint that follows
+the chat-completions contract.
+
+### Configuring for Gemini
+
+Gemini exposes its OpenAI-compatible layer under a non-standard base path. Set
+`OPENAI_COMPATIBLE_BASEPATH` to `/v1beta/openai` before calling the function — either
+for the current job or persistently for your user profile:
+
+```sql
+-- For the current job only
+CALL dbsdk_v1.openai_compatible_setserverforjob('generativelanguage.googleapis.com');
+CALL dbsdk_v1.openai_compatible_setportforjob(443);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob('https');
+CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1beta/openai');
+CALL dbsdk_v1.openai_compatible_setapikeyforjob('your-gemini-api-key');
+CALL dbsdk_v1.openai_compatible_setmodelforjob('gemini-3.6-flash');
+```
+
+If you manage connection settings through the `DBSDK_V1.CONF` data file, set the
+`OPENAI_COMPATIBLE_BASEPATH` key to `/v1beta/openai`.
+
+### `openai_compatible_chat_generate`
+
+```sql
+SELECT dbsdk_v1.openai_compatible_chat_generate(
+  'What is Db2 for i?'
+) FROM sysibm.sysdummy1;
+```
+
+The function wraps the prompt as a `user`-role message inside a `messages` array and
+POSTs to `/chat/completions`. It returns the text content of
+`choices[0].message.content` from the response, or the full JSON body if that path
+cannot be parsed.
+
+**Strict-field safety.** The request body starts with only `model` and `messages`.
+Every other parameter (`max_tokens`, `temperature`, `top_p`, `n`, `presence_penalty`,
+`frequency_penalty`, `stop`, `seed`, `user`) is only appended to the JSON when
+explicitly present in the `options` argument. This makes the function safe for strict
+endpoints like Gemini while remaining fully configurable for permissive ones.
+
+#### Supported Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model_id` | string | (configured model) | The model to use for generation |
+| `max_tokens` | integer | 256 | Maximum number of tokens to generate |
+| `temperature` | decimal | 1.0 | Controls randomness (0–2). Lower is more deterministic |
+| `top_p` | decimal | 1.0 | Nucleus sampling probability cutoff |
+| `n` | integer | 1 | Number of completions to generate |
+| `presence_penalty` | decimal | 0.0 | Penalty between -2.0 and 2.0 for tokens based on presence |
+| `frequency_penalty` | decimal | 0.0 | Penalty between -2.0 and 2.0 for tokens based on frequency |
+| `stop` | string | null | Sequences where generation should stop |
+| `seed` | integer | null | Seed for deterministic sampling |
+| `user` | string | null | Unique identifier for the end user |
+
+:::note
+Parameters not present in the `options` JSON are **not sent** in the HTTP request
+body at all. Only include parameters that you explicitly want to control.
+:::
+
 ## API Response Format
 
-The OpenAI-compatible API response follows this structure:
+The two generation functions use different response schemas. The regular `generate`
+and `generate_json` functions target the **text-completion** schema, while
+`openai_compatible_chat_generate` targets the **chat-completion** schema.
+
+| | `openai_compatible_generate` / `openai_compatible_generate_json` | `openai_compatible_chat_generate` |
+|---|---|---|
+| Endpoint | `/completions` | `/chat/completions` |
+| Extracted field | `choices[0].text` | `choices[0].message.content` |
+| Response `object` | `"text_completion"` | `"chat.completion"` |
+
+**Text-completion response** (`/completions` — used by `generate` / `generate_json`):
 
 ```json
 {
@@ -161,28 +243,41 @@ The OpenAI-compatible API response follows this structure:
   ],
   "created": 1746039098,
   "model": "llama3",
-  "system_fingerprint": "b5043-c262bedd",
   "object": "text_completion",
   "usage": {
     "completion_tokens": 100,
     "prompt_tokens": 13,
     "total_tokens": 113
   },
-  "id": "chatcmpl-OW6vxJUGFMwUyg6HPGHYO1Uaza3VeXRj",
-  "timings": {
-    "prompt_n": 13,
-    "prompt_ms": 418.129,
-    "prompt_per_token_ms": 32.16376923076923,
-    "prompt_per_second": 31.090883435494785,
-    "predicted_n": 100,
-    "predicted_ms": 14705.362,
-    "predicted_per_token_ms": 147.05362,
-    "predicted_per_second": 6.8002406197140886
-  }
+  "id": "chatcmpl-OW6vxJUGFMwUyg6HPGHYO1Uaza3VeXRj"
 }
 ```
 
-The regular `generate` function extracts just the text content from `choices[0].text`, while the `generate_json` function returns the entire JSON response.
+**Chat-completion response** (`/chat/completions` — used by `openai_compatible_chat_generate`):
+
+```json
+{
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "** GENERATED TEXT HERE **"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "created": 1746039098,
+  "model": "gemini-3.6-flash",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 100,
+    "prompt_tokens": 13,
+    "total_tokens": 113
+  },
+  "id": "chatcmpl-abc123"
+}
+```
 
 ## Authentication
 

--- a/src/openai_compatible/generate.sql
+++ b/src/openai_compatible/generate.sql
@@ -392,3 +392,201 @@ begin
 
   return null;
 end;
+
+
+-- #### **Function:** `openai_compatible_chat_generate`
+
+-- **Description:** Uses an OpenAI-compatible `/chat/completions` endpoint to generate a
+-- reply to the given prompt. Unlike `openai_compatible_generate` (which uses the legacy
+-- `/completions` endpoint with a top-level `"prompt"` field), this function wraps the
+-- prompt in a `messages` array as required by Gemini and other modern chat-completion
+-- endpoints.
+-- 
+-- **Input parameters:**
+-- - `PROMPT` (required): The input prompt for the LLM (sent as a `user` role message).
+-- - `options` (optional): JSON object containing optional parameters:
+--   - `model_id`: The model identifier to use for generation.
+--   - `max_tokens`: Maximum number of tokens to generate. Default 256.
+--   - `temperature`: Sampling temperature between 0 and 2. Default 1.
+--   - `top_p`: Nucleus sampling probability mass. Default 1.
+--   - `n`: Number of completions to generate. Default 1.
+--   - `presence_penalty`: Penalty between -2.0 and 2.0 for tokens based on presence. Default 0.
+--   - `frequency_penalty`: Penalty between -2.0 and 2.0 for tokens based on frequency. Default 0.
+--   - `stop`: Up to 4 sequences where generation should stop.
+--   - `seed`: Seed for deterministic sampling.
+--   - `user`: Unique identifier for the end user.
+-- - `api_key_` (optional): API key for authentication. If not provided, uses configured key.
+-- - `base_url` (optional): Base URL for the API endpoint (must end before `/chat/completions`).
+--   If not provided, uses configured endpoint settings.
+-- 
+-- **Return type:**
+-- - `clob(2G) ccsid 1208`
+-- 
+-- **Return value:**
+-- - The text content of `choices[0].message.content` from the API response,
+--   or the full JSON body if that path cannot be parsed.
+
+create or replace function dbsdk_v1.openai_compatible_chat_generate(
+  prompt varchar(32000) ccsid 1208,
+  options varchar(32000) ccsid 1208 default '{}',
+  api_key_  varchar(8000) ccsid 1208 default NULL,
+  base_url varchar(1000) ccsid 1208 default NULL
+)
+  returns clob(2G) ccsid 1208
+  modifies sql data
+  not deterministic
+  no external action
+  set option usrprf = *user, dynusrprf = *user, commit = *none
+begin
+  declare fullUrl varchar(32500) ccsid 1208 default NULL;
+  declare response_header clob(32K) ccsid 1208;
+  declare response_message clob(2G) ccsid 1208;
+  declare response_code int default 500;
+  declare api_key varchar(8000) ccsid 1208;
+  declare http_options varchar(32400) ccsid 1208;
+  declare response_text clob(2G) ccsid 1208;
+  declare req_body clob(64K) ccsid 1208;
+
+  -- Extract parameters from options
+  declare model_id varchar(1000) ccsid 1208;
+  declare max_tokens integer default 256;
+  declare temperature decimal(3,1);
+  declare top_p decimal(3,1);
+  declare n integer;
+  declare stop_token varchar(32000) ccsid 1208;
+  declare presence_penalty decimal(3,1);
+  declare frequency_penalty decimal(3,1);
+  declare user_id varchar(1000) ccsid 1208;
+  declare seed integer;
+
+  -- Get parameters from options JSON
+  set model_id          = json_value(options, '$.model_id');
+  set max_tokens        = coalesce(json_value(options, '$.max_tokens'), 256);
+  set temperature       = coalesce(json_value(options, '$.temperature'), 1);
+  set top_p             = coalesce(json_value(options, '$.top_p'), 1);
+  set n                 = coalesce(json_value(options, '$.n'), 1);
+  set stop_token        = json_value(options, '$.stop');
+  set presence_penalty  = coalesce(json_value(options, '$.presence_penalty'), 0);
+  set frequency_penalty = coalesce(json_value(options, '$.frequency_penalty'), 0);
+  set user_id           = json_value(options, '$.user');
+  set seed              = json_value(options, '$.seed');
+
+  -- Get API key for authentication
+  if (api_key_ is null) then
+    set api_key = dbsdk_v1.openai_compatible_getapikey();
+  else
+    set api_key = api_key_;
+  end if;
+
+  -- Build the URL for the chat completions endpoint
+  if (base_url is not null and trim(base_url) <> '') then
+    set fullUrl = base_url concat '/chat/completions';
+  else
+    set fullUrl = dbsdk_v1.openai_compatible_getprotocol() concat '://'
+                concat dbsdk_v1.openai_compatible_getserver()
+                concat ':' concat dbsdk_v1.openai_compatible_getport()
+                concat dbsdk_v1.openai_compatible_getbasepath()
+                concat '/chat/completions';
+  end if;
+
+  -- Set HTTP options including headers
+  if (api_key is not null and trim(api_key) <> '') then
+    set http_options = json_object(
+      'ioTimeout': 2000000,
+      'headers': json_object(
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' concat api_key
+      )
+    );
+  else
+    set http_options = json_object(
+      'ioTimeout': 2000000,
+      'headers': json_object(
+        'Content-Type': 'application/json'
+      )
+    );
+  end if;
+
+  -- Build the chat-completions request body.
+  -- The prompt is wrapped in a messages array as a user-role message,
+  -- which is required by chat-completion endpoints (e.g. Gemini, GPT-4).
+  -- Only the mandatory fields are included unconditionally; all other
+  -- parameters are added only when explicitly supplied in options, because
+  -- some endpoints (e.g. Gemini) return 400 for unrecognised/unsupported
+  -- fields even when they carry OpenAI default values.
+  set req_body = json_object(
+    'model':    coalesce(model_id, dbsdk_v1.openai_compatible_getmodel()),
+    'messages': json_array(
+                  json_object('role': 'user', 'content': prompt)
+                )
+  );
+
+  -- Add optional parameters only when explicitly present in options
+  if (json_value(options, '$.max_tokens') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.max_tokens', max_tokens);
+  end if;
+
+  if (json_value(options, '$.temperature') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.temperature', temperature);
+  end if;
+
+  if (json_value(options, '$.top_p') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.top_p', top_p);
+  end if;
+
+  if (json_value(options, '$.n') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.n', n);
+  end if;
+
+  if (json_value(options, '$.presence_penalty') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.presence_penalty', presence_penalty);
+  end if;
+
+  if (json_value(options, '$.frequency_penalty') is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.frequency_penalty', frequency_penalty);
+  end if;
+
+  if (stop_token is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.stop', stop_token);
+  end if;
+
+  if (seed is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.seed', seed);
+  end if;
+
+  if (user_id is not null) then
+    set req_body = JSON_UPDATE(req_body, 'SET', '$.user', user_id);
+  end if;
+
+  -- Make the API call
+  select response_message, response_http_header
+  into response_message, response_header
+  from table(qsys2.http_post_verbose(
+               fullUrl,
+               req_body,
+               http_options));
+
+  -- Get HTTP status code
+  set response_code = json_value(response_header, '$.HTTP_STATUS_CODE');
+
+  -- Process the response
+  if (response_code >= 200 and response_code < 300) then
+    -- Extract the content from choices[0].message.content (chat completions schema)
+    set response_text = json_value(response_message,
+                          '$.choices[0].message.content'
+                          returning clob(2G) ccsid 1208);
+
+    -- If parse fails, return the entire JSON response as a fallback
+    if (response_text is null) then
+      call systools.lprintf('openai_compatible_chat_generate: content parse failed, returning full response');
+      return response_message;
+    end if;
+
+    return response_text;
+  end if;
+
+  set response_text = 'An error has occured. Check the job log. HTTP response code was '
+                      concat response_code concat ' from ' concat fullUrl;
+  signal sqlstate '38002' set message_text = response_text;
+  return null;
+end;


### PR DESCRIPTION
Function openai_compatible_generate() does not work with Gemini.
Added function openai_compatible_chat_generate() which does work with Gemini

Per IBM Bob:

> Root cause — two compounding issues:
> 
> openai_compatible_generate posts to /completions with a "prompt" field — the legacy text-completion format. Gemini only implements the chat-completion API.
> 
> Even after targeting /chat/completions with a "messages" body, Gemini returns 400 if the request contains any field it doesn't support — n, top_p, presence_penalty, frequency_penalty — even when they carry standard OpenAI default values. Gemini's compatibility layer is strict about unknown/unsupported fields.
> 
> What was done:
> 
> Added [dbsdk_v1.openai_compatible_chat_generate](vscode-webview://0jaglev2h9f9s85nhad2o2m4a8j4r0d08oaab71fadpct6676igi/src/openai_compatible/generate.sql:429) to generate.sql — targets /chat/completions, wraps the prompt as messages: [{role: user, content: …}], and extracts choices[0].message.content from the response.
> 
> The body starts with only model + messages. Every other parameter (max_tokens, temperature, top_p, n, presence_penalty, frequency_penalty, stop, seed, user) is only added to the JSON when explicitly present in the options argument, making it safe for strict endpoints like Gemini while still being fully configurable for permissive ones.