### PR TITLE
Bug fix and test coverage expansion

### DIFF
--- a/src/ollama/utils.sql
+++ b/src/ollama/utils.sql
@@ -36,8 +36,9 @@ end;
 
 -- **Input parameters:**
 -- - `HOSTNAME` (required): The IP address or hostname of the ollama server.
-create or replace procedure dbsdk_v1.ollama_setserverforme(hostname varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.ollama_setserverforme(hostname varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, hostname AS ollama_server
@@ -85,8 +86,9 @@ end;
 
 -- **Input parameters:**
 -- - `PORT` (required): The ollama server port.
-create or replace procedure dbsdk_v1.ollama_setportforme(port INT default NULL) 
+create or replace procedure dbsdk_v1.ollama_setportforme(port INT default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, port AS ollama_port
@@ -134,8 +136,9 @@ end;
 
 -- **Input parameters:**
 -- - `MODEL` (required): The ollama identifier of the model to use.
-create or replace procedure dbsdk_v1.ollama_setmodelforme(model varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.ollama_setmodelforme(model varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, model AS ollama_model
@@ -182,8 +185,9 @@ end;
 -- 
 -- **Input parameters:**
 -- - `PROTOCOL` (required): `http`/`https`
-create or replace procedure dbsdk_v1.ollama_setprotocolforme(protocol varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.ollama_setprotocolforme(protocol varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, protocol AS ollama_protocol

--- a/src/openai_compatible/utils.sql
+++ b/src/openai_compatible/utils.sql
@@ -32,8 +32,9 @@ end;
 
 -- **Input parameters:**
 -- - `HOSTNAME` (required): The IP address or hostname of the OpenAI-compatible server.
-create or replace procedure dbsdk_v1.openai_compatible_setserverforme(hostname varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setserverforme(hostname varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, hostname AS openai_compatible_server
@@ -77,8 +78,9 @@ end;
 
 -- **Input parameters:**
 -- - `PORT` (required): The OpenAI-compatible server port.
-create or replace procedure dbsdk_v1.openai_compatible_setportforme(port INT default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setportforme(port INT default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, port AS openai_compatible_port
@@ -122,8 +124,9 @@ end;
 
 -- **Input parameters:**
 -- - `MODEL` (required): The model identifier to use.
-create or replace procedure dbsdk_v1.openai_compatible_setmodelforme(model varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setmodelforme(model varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, model AS openai_compatible_model
@@ -167,8 +170,9 @@ end;
 -- 
 -- **Input parameters:**
 -- - `PROTOCOL` (required): `http`/`https`
-create or replace procedure dbsdk_v1.openai_compatible_setprotocolforme(protocol varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setprotocolforme(protocol varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, protocol AS openai_compatible_protocol
@@ -213,8 +217,9 @@ end;
 -- 
 -- **Input parameters:**
 -- - `API_KEY` (required): The API key for authentication.
-create or replace procedure dbsdk_v1.openai_compatible_setapikeyforme(api_key varchar(8000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setapikeyforme(api_key varchar(8000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, api_key AS openai_compatible_apikey
@@ -259,8 +264,9 @@ end;
 -- 
 -- **Input parameters:**
 -- - `BASE_PATH` (required): The base path for API endpoints.
-create or replace procedure dbsdk_v1.openai_compatible_setbasepathforme(base_path varchar(1000) ccsid 1208 default NULL) 
+create or replace procedure dbsdk_v1.openai_compatible_setbasepathforme(base_path varchar(1000) ccsid 1208 default NULL)
   MODIFIES SQL DATA
+  set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   MERGE INTO dbsdk_v1.conf tt USING (
     SELECT CURRENT_USER AS usrprf, base_path AS openai_compatible_basepath

--- a/test/README_TESTING.md
+++ b/test/README_TESTING.md
@@ -14,6 +14,7 @@ This directory contains SQL test scripts for the `dbsdk_v1` schema on IBM i.
 | [`test_json_object_update.sql`](test_json_object_update.sql) | `json_object_update` utility function | No |
 | [`ollama_test.sql`](ollama_test.sql) | `ollama` — config utils, `set*forme` persistence, `ollama_generate` | Yes — Ollama server |
 | [`openai_compatible_chat_generate_test.sql`](openai_compatible_chat_generate_test.sql) | `openai_compatible_chat_generate`, `set*forme` persistence | Optional (local and/or cloud) |
+| [`grant_test_user.sql`](grant_test_user.sql) | Setup — grants authority to the test user profile | No (run as schema owner) |
 
 ---
 
@@ -26,21 +27,41 @@ This directory contains SQL test scripts for the `dbsdk_v1` schema on IBM i.
 
 ### 2. Test user profile
 
-Scripts that write to `dbsdk_v1.conf` or call live endpoints must be run as a **dedicated test IBM i user profile**.  
+Scripts that write to `dbsdk_v1.conf` or call live endpoints must be run as a **dedicated test IBM i user profile**.
 The default expected profile name is **`DBSDKTEST`**.
 
-To use a different profile, edit the `SET` statement near the top of each applicable script:
-
-```sql
-SET dbsdk_v1.test_user = 'DBSDKTEST';  -- change this value
-```
+To use a different profile, search for `<<CHANGE_TEST_USER>>` in each applicable script and replace
+`'DBSDKTEST'` with your profile name. The marker appears in the user guard and teardown statements.
 
 The test profile needs:
-- `*USE` authority to the `dbsdk_v1` library and all objects within it.
-- `*CHANGE` authority to `dbsdk_v1.conf` (for `set*forme` and teardown `DELETE` statements).
+- `*EXECUTE` authority on every `dbsdk_v1` function and procedure it calls.
+- `SELECT`, `INSERT`, `UPDATE`, `DELETE` authority on `dbsdk_v1.conf`.
 - Network access from the IBM i job to any endpoint under test (Ollama, OpenAI-compatible server, etc.).
 
-### 3. Registering the test user profile
+### 3. Granting authority to the test profile
+
+The functions and procedures in `dbsdk_v1` are compiled without an explicit `set option usrprf`
+clause in the utility modules, so they default to `USRPRF(*OWNER)`. A user other than the schema
+owner will receive `SQL0551 Not authorized to object … type *PGM` (or `type *SRVPGM`) when calling them.
+
+Run [`test/grant_test_user.sql`](grant_test_user.sql) **once** as the schema owner (or any profile
+with `*SECADM` special authority) before running any test scripts:
+
+```
+-- In ACS Run SQL Scripts, connected as the schema owner:
+-- Open test/grant_test_user.sql and run all statements.
+
+-- Or from a 5250 command line:
+RUNSQLSTM SRCSTMF('/path/to/test/grant_test_user.sql') COMMIT(*NONE) NAMING(*SQL)
+```
+
+If you rename the test profile from `DBSDKTEST`, also edit every occurrence of `DBSDKTEST` in
+`grant_test_user.sql` before running it (or run the individual `GRANT` statements manually).
+
+Re-run `grant_test_user.sql` any time the schema is rebuilt, since `CREATE OR REPLACE` drops and
+re-creates the compiled program object and resets its authority list.
+
+### 4. Registering the test user profile
 
 Before running any test that calls `set*forme` procedures or live generate functions, the test user's
 row must exist in `dbsdk_v1.conf`. The simplest way to create it (as the test user):
@@ -147,12 +168,26 @@ Requires a running [Ollama](https://ollama.com/) server reachable from the IBM i
 one model pulled. The `dbsdk_v1.conf` row for the test user must have `ollama_server` set (Guard 2
 checks this before any live calls are made).
 
-The explicit-model test uses `granite3.2:8b` as the default model name. Change this to any model
+The script has three sections:
+- **Section 1** — `set*forjob` / `get*` round-trips (no live endpoint call, just job-variable manipulation)
+- **Section 2** — `set*forme` persistence tests (writes and reads `dbsdk_v1.conf`; teardown deletes the row)
+- **Section 3** — live `ollama_generate` calls; uses explicit `setserverforjob`/`setportforjob`/`setprotocolforjob` calls so it does not depend on the conf row deleted by Section 2
+
+⚠️ **Before running Section 3**, check the four `CALL` statements just above it in the script and edit them to match your environment:
+
+```sql
+CALL dbsdk_v1.ollama_setserverforjob('localhost');    -- change if different
+CALL dbsdk_v1.ollama_setportforjob(11434);            -- change if different
+CALL dbsdk_v1.ollama_setprotocolforjob('http');       -- change if different
+CALL dbsdk_v1.ollama_setmodelforjob('granite4.1:8b'); -- change to any pulled model
+```
+
+The explicit-model test also uses `granite4.1:8b` as the model name. Change this to any model
 that is pulled on your Ollama server:
 
 ```sql
 -- Near the bottom of ollama_test.sql:
-WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite3.2:8b') IS NOT NULL
+WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite4.1:8b') IS NOT NULL
 ```
 
 ### `openai_compatible_chat_generate_test.sql`
@@ -210,3 +245,19 @@ test row:
 ```sql
 DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';
 ```
+
+---
+
+## Known limitations
+
+### Bare `SET` on global variables requires `*SRVPGM` authority
+
+`SET dbsdk_v1.<variable> = value` is a direct write to the `*SRVPGM` object that backs the global
+variable. IBM i checks `*CHANGE` authority on that object before SQL privilege evaluation; this
+authority cannot be granted via `GRANT` statements from SQL. For this reason, the test scripts never
+use bare `SET` to write `dbsdk_v1.*` variables — all variable writes are routed through the
+`set*forjob` procedures, which run as `*OWNER` and have full authority on the `*SRVPGM`.
+
+`CREATE OR REPLACE VARIABLE` similarly requires `*ADD` authority on the schema, which `DBSDKTEST`
+does not hold. The test scripts therefore use hardcoded string literals for the test profile name
+(marked `<<CHANGE_TEST_USER>>`) rather than a global variable.

--- a/test/README_TESTING.md
+++ b/test/README_TESTING.md
@@ -61,7 +61,38 @@ If you rename the test profile from `DBSDKTEST`, also edit every occurrence of `
 Re-run `grant_test_user.sql` any time the schema is rebuilt, since `CREATE OR REPLACE` drops and
 re-creates the compiled program object and resets its authority list.
 
-### 4. Registering the test user profile
+### 4. SSL certificate store access (HTTPS endpoints only)
+
+Tests that call cloud HTTPS endpoints (e.g. Gemini, OpenAI) use `QSYS2.HTTP_POST_VERBOSE` with
+`set option usrprf = *user`, meaning the HTTP call runs as the test user profile. IBM i's GSKit SSL
+layer opens the system key database (`*SYSTEM` DCM certificate store) as that user. If `DBSDKTEST`
+does not have read authority on the keystore, the call fails with:
+
+```
+GSKit Error 6003 - Access to the key database is not allowed
+```
+
+To grant the minimum necessary IFS authority, run the following **as a security administrator**
+(`*SECADM` or `*ALLOBJ`) from a 5250 command line:
+
+```
+CHGAUT OBJ('/QIBM/UserData/ICSS/Cert/Server') USER(DBSDKTEST) DTAAUT(*RX)
+CHGAUT OBJ('/QIBM/UserData/ICSS/Cert/Server/DEFAULT.KDB') USER(DBSDKTEST) DTAAUT(*R)
+```
+
+The first command grants traverse (`*RX`) on the directory only; the second grants read (`*R`) on
+the keystore file itself. No other files in the directory are affected.
+
+To verify the current authority on the keystore file:
+
+```
+WRKAUT OBJ('/QIBM/UserData/ICSS/Cert/Server/DEFAULT.KDB')
+```
+
+If you have renamed the test profile from `DBSDKTEST`, substitute your profile name in the commands
+above. This is a one-time step and does not need to be repeated when the schema is rebuilt.
+
+### 5. Registering the test user profile
 
 Before running any test that calls `set*forme` procedures or live generate functions, the test user's
 row must exist in `dbsdk_v1.conf`. The simplest way to create it (as the test user):

--- a/test/README_TESTING.md
+++ b/test/README_TESTING.md
@@ -1,0 +1,212 @@
+# Testing Guide
+
+This directory contains SQL test scripts for the `dbsdk_v1` schema on IBM i.
+
+---
+
+## Contents
+
+| File | Module(s) tested | Requires live endpoint? |
+|---|---|---|
+| [`a.sql`](a.sql) | `watsonx` — auth, generate, models, utils | Yes — watsonx cloud |
+| [`openai_compatible_test.sql`](openai_compatible_test.sql) | `openai_compatible` — job-scope config, `generate`, `generate_json` | Yes — OpenAI-compatible server |
+| [`test_fix.sql`](test_fix.sql) | `conf` — MERGE row-isolation regression (issue #21/#27) | No |
+| [`test_json_object_update.sql`](test_json_object_update.sql) | `json_object_update` utility function | No |
+| [`ollama_test.sql`](ollama_test.sql) | `ollama` — config utils, `set*forme` persistence, `ollama_generate` | Yes — Ollama server |
+| [`openai_compatible_chat_generate_test.sql`](openai_compatible_chat_generate_test.sql) | `openai_compatible_chat_generate`, `set*forme` persistence | Optional (local and/or cloud) |
+
+---
+
+## Prerequisites
+
+### 1. IBM i environment
+
+- IBM i with Db2 for i (any currently supported release).
+- The `dbsdk_v1` schema must be built and deployed. See the project build instructions in the root `makefile`.
+
+### 2. Test user profile
+
+Scripts that write to `dbsdk_v1.conf` or call live endpoints must be run as a **dedicated test IBM i user profile**.  
+The default expected profile name is **`DBSDKTEST`**.
+
+To use a different profile, edit the `SET` statement near the top of each applicable script:
+
+```sql
+SET dbsdk_v1.test_user = 'DBSDKTEST';  -- change this value
+```
+
+The test profile needs:
+- `*USE` authority to the `dbsdk_v1` library and all objects within it.
+- `*CHANGE` authority to `dbsdk_v1.conf` (for `set*forme` and teardown `DELETE` statements).
+- Network access from the IBM i job to any endpoint under test (Ollama, OpenAI-compatible server, etc.).
+
+### 3. Registering the test user profile
+
+Before running any test that calls `set*forme` procedures or live generate functions, the test user's
+row must exist in `dbsdk_v1.conf`. The simplest way to create it (as the test user):
+
+```sql
+CALL dbsdk_v1.conf_register_user();
+```
+
+Then populate the endpoint details using either the `CFGOLLAMA` / `CFGOPENAI` admin programs in
+`src/admin/`, the `conf_update_*` admin procedures in `src/admin/sql/conf_admin.sql`, or direct
+`set*forme` calls — for example:
+
+```sql
+-- Ollama example
+CALL dbsdk_v1.ollama_setserverforme('my-ollama-host');
+CALL dbsdk_v1.ollama_setportforme(11434);
+CALL dbsdk_v1.ollama_setprotocolforme('http');
+CALL dbsdk_v1.ollama_setmodelforme('granite3.2:8b');
+
+-- OpenAI-compatible local example
+CALL dbsdk_v1.openai_compatible_setserverforme('localhost');
+CALL dbsdk_v1.openai_compatible_setportforme(8080);
+CALL dbsdk_v1.openai_compatible_setprotocolforme('http');
+CALL dbsdk_v1.openai_compatible_setbasepathforme('/v1');
+CALL dbsdk_v1.openai_compatible_setmodelforme('llama3');
+```
+
+---
+
+## How to run
+
+### Option A — ACS Run SQL Scripts (recommended for interactive use)
+
+1. Open IBM i Access Client Solutions (ACS).
+2. Connect to your IBM i system as the test user profile (`DBSDKTEST`).
+3. Open **Run SQL Scripts** (`File → New SQL Script` or toolbar button).
+4. Open or paste the `.sql` file you want to run.
+5. Click **Run All** (F5) or run selected statements individually.
+6. Results appear in the **Results** tab. Look for `PASS:` / `FAIL:` values in result columns and
+   check the **Messages** tab for any signals raised by guard blocks.
+
+> **Tip:** Scripts that require endpoint-specific values (server address, API key, model name) have
+> clearly marked comment blocks at the top of the relevant section. Edit those values in the ACS
+> editor before running.
+
+### Option B — RUNSQLSTM on IBM i (batch / CI use)
+
+The project's `runsql.sh` wrapper calls `RUNSQLSTM` directly. To run a test script from a PASE shell:
+
+```sh
+runsql.sh dbsdk_v1 test/ollama_test.sql
+```
+
+Or directly with `RUNSQLSTM` from a 5250 command line:
+
+```
+RUNSQLSTM SRCSTMF('/path/to/test/ollama_test.sql') COMMIT(*NONE) NAMING(*SQL) DFTRDBCOL(DBSDK_V1)
+```
+
+---
+
+## Understanding test output
+
+### PASS / FAIL assertions
+
+Most tests produce a result row with a single column named `TEST_RESULT`. A passing test looks like:
+
+```
+TEST_RESULT
+---------------------------------------------------------
+PASS: ollama_setserverforjob / ollama_getserver round-trip
+```
+
+A failure looks like:
+
+```
+TEST_RESULT
+---------------------------------------------------------
+FAIL: ollama_setserverforjob / ollama_getserver round-trip
+```
+
+In ACS Run SQL Scripts, all result sets appear in the **Results** tab. Scan for any `FAIL:` prefix.
+
+### Guard signals
+
+Scripts that detect a misconfiguration or wrong user raise an SQL signal that stops execution immediately.
+
+| SQLSTATE | Meaning |
+|---|---|
+| `45000` | Script is not being run as the expected test user profile. Edit `dbsdk_v1.test_user`. |
+| `45001` | Required endpoint configuration is missing (server, model, etc.) for the Ollama or local OpenAI-compatible block. |
+| `45002` | Cloud API key is not set. Edit the `setapikeyforjob` call at the top of the cloud sub-block. |
+
+In ACS, a signal appears as an error message in the **Messages** tab. In `RUNSQLSTM`, it appears in
+the job log.
+
+---
+
+## Script-by-script notes
+
+### `ollama_test.sql`
+
+Requires a running [Ollama](https://ollama.com/) server reachable from the IBM i job, with at least
+one model pulled. The `dbsdk_v1.conf` row for the test user must have `ollama_server` set (Guard 2
+checks this before any live calls are made).
+
+The explicit-model test uses `granite3.2:8b` as the default model name. Change this to any model
+that is pulled on your Ollama server:
+
+```sql
+-- Near the bottom of ollama_test.sql:
+WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite3.2:8b') IS NOT NULL
+```
+
+### `openai_compatible_chat_generate_test.sql`
+
+Has three independent sections:
+
+**LOCAL sub-block** — targets a locally-hosted OpenAI-compatible server (e.g. llama.cpp,
+LM Studio, Ollama's `/v1` shim). Edit the `setserverforjob` / `setportforjob` / `setmodelforjob`
+calls at the top of the block to match your local setup. If the server or model is `NULL` after
+setup, Guard `45001` fires and the block is skipped cleanly.
+
+**CLOUD sub-block** — targets a cloud endpoint (e.g. `api.openai.com`, Gemini). You must provide
+a real API key:
+
+```sql
+-- In the CLOUD ENDPOINT SUB-BLOCK section:
+CALL dbsdk_v1.openai_compatible_setapikeyforjob('sk-your-real-api-key-here');
+```
+
+Also update `setserverforjob` and `setmodelforjob` for your chosen cloud provider. If the API key
+is `NULL`, Guard `45002` fires and the block is skipped cleanly.
+
+**`set*forme` persistence tests** — always run regardless of whether either endpoint guard fired.
+These tests do not make any network calls; they only write to and read from `dbsdk_v1.conf`.
+
+### `test_fix.sql`
+
+No live endpoint required. Inserts synthetic rows for fictional users `TEST1` and `TEST2`, verifies
+MERGE row-isolation, and cleans up. Can be run as any user that has `*CHANGE` authority to
+`dbsdk_v1.conf`.
+
+### `test_json_object_update.sql`
+
+No live endpoint required. All 11 tests run as pure SQL expressions against `sysibm.sysdummy1`.
+Expected output is documented in inline comments. Can be run as any user.
+
+### `openai_compatible_test.sql`
+
+Requires a locally-hosted OpenAI-compatible server. Edit the `setserverforjob` / `setportforjob` /
+`setprotocolforjob` / `setbasepathforjob` calls at the top before running.
+
+### `a.sql`
+
+Requires a watsonx cloud account. The watsonx API key and project ID must be set in
+`dbsdk_v1.conf` for the running user (or set via `wx_setapikeyforjob` / `wx_setprojectidforjob`).
+
+---
+
+## Cleanup
+
+All test scripts that write to `dbsdk_v1.conf` clean up after themselves with a `DELETE` at the end.
+If a script is interrupted mid-run (e.g. a guard signal fires), you can manually remove any leftover
+test row:
+
+```sql
+DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';
+```

--- a/test/grant_test_user.sql
+++ b/test/grant_test_user.sql
@@ -1,0 +1,71 @@
+-- ============================================================
+-- Grant authority to the test user profile on dbsdk_v1 objects
+-- ============================================================
+-- Run this script ONCE as the dbsdk_v1 schema owner (or a user
+-- with *SECADM authority) BEFORE running any test scripts.
+--
+-- Change 'DBSDKTEST' below to match your test user profile if
+-- you have changed dbsdk_v1.test_user in the test scripts.
+-- ============================================================
+
+-- Table: grant the privileges needed by DBSDKTEST on dbsdk_v1.conf.
+--
+-- SELECT  - PASS/FAIL assertion queries read dbsdk_v1.conf directly
+-- INSERT  - conf_register_user / conf_initialize run with usrprf=*user
+-- UPDATE  - set*forme procedures run with usrprf=*user (after source fix),
+--           so the MERGE WHEN MATCHED THEN UPDATE branch runs as DBSDKTEST
+-- DELETE  - teardown statements run as bare SQL as DBSDKTEST
+--
+-- Row Access Control (conf_rcac.sql MYROWONLY, ENFORCED FOR ALL ACCESS)
+-- independently limits every operation to the DBSDKTEST row regardless
+-- of the object-level privileges granted here.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE dbsdk_v1.conf TO DBSDKTEST;
+
+-- All functions and procedures: allow the test user to call them
+-- Re-run this script after rebuilding the schema to pick up new objects.
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.ollama_getserver           TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.ollama_getport             TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.ollama_getmodel            TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.ollama_getprotocol         TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setserverforjob     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setserverforme      TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setportforjob       TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setportforme        TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setmodelforjob      TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setmodelforme       TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setprotocolforjob   TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.ollama_setprotocolforme    TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.ollama_generate            TO DBSDKTEST;
+
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getserver       TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getport         TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getmodel        TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getprotocol     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getapikey       TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_getbasepath     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setserverforjob   TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setserverforme    TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setportforjob     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setportforme      TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setmodelforjob    TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setmodelforme     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setprotocolforjob TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setprotocolforme  TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setapikeyforjob   TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setapikeyforme    TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setbasepathforjob TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.openai_compatible_setbasepathforme  TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_generate          TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_generate_json     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.openai_compatible_chat_generate     TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC FUNCTION  dbsdk_v1.json_object_update                  TO DBSDKTEST;
+
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.conf_register_user  TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.conf_initialize      TO DBSDKTEST;
+GRANT EXECUTE ON SPECIFIC PROCEDURE dbsdk_v1.conf_remove_user     TO DBSDKTEST;
+
+-- Note: bare SET dbsdk_v1.<variable> = ... statements are NOT used in the
+-- test scripts because SET on a global variable requires *CHANGE on the
+-- underlying *SRVPGM object, which cannot be granted via SQL GRANT.
+-- All variable writes are routed through the set*forjob procedures instead,
+-- which run as *OWNER and have no authority issue.

--- a/test/ollama_test.sql
+++ b/test/ollama_test.sql
@@ -1,0 +1,145 @@
+-- ============================================================
+-- Test script for the ollama module
+-- ============================================================
+-- Covers:
+--   - set*forjob / get* round-trips (server, port, model, protocol)
+--   - set*forme persistence (writes to dbsdk_v1.conf)
+--   - ollama_generate() with default model
+--   - ollama_generate() with explicit model_id
+--
+-- Run as: the user profile named in dbsdk_v1.test_user (default: DBSDKTEST)
+-- Compatible with: ACS Run SQL Scripts, RUNSQLSTM / runsql.sh
+-- ============================================================
+
+-- ----------------------------------------
+-- Configurable test user profile name.
+-- Edit the SET statement below to change it.
+-- ----------------------------------------
+CREATE OR REPLACE VARIABLE dbsdk_v1.test_user VARCHAR(10) DEFAULT 'DBSDKTEST';
+SET dbsdk_v1.test_user = 'DBSDKTEST';
+
+-- ----------------------------------------
+-- Guard 1: must be run as test_user
+-- ----------------------------------------
+BEGIN
+  IF CURRENT_USER <> dbsdk_v1.test_user THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit dbsdk_v1.test_user to change)';
+  END IF;
+END;
+
+-- ----------------------------------------
+-- Guard 2: ollama server must be configured
+-- in dbsdk_v1.conf for test_user.
+-- Job-scope variables are intentionally left
+-- unset here — ollama_getserver() will fall
+-- through to the conf row (see src/ollama/utils.sql).
+-- ----------------------------------------
+BEGIN
+  IF dbsdk_v1.ollama_getserver() IS NULL THEN
+    SIGNAL SQLSTATE '45001'
+      SET MESSAGE_TEXT = 'Ollama server not configured for test_user — add a conf row for DBSDKTEST and retry';
+  END IF;
+END;
+
+-- ============================================================
+-- Section 1: set*forjob / get* round-trips
+-- ============================================================
+
+-- Server
+CALL dbsdk_v1.ollama_setserverforjob('test-ollama-host');
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_getserver() = 'test-ollama-host'
+    THEN 'PASS: ollama_setserverforjob / ollama_getserver round-trip'
+    ELSE 'FAIL: ollama_setserverforjob / ollama_getserver round-trip'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Port
+CALL dbsdk_v1.ollama_setportforjob(19999);
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_getport() = 19999
+    THEN 'PASS: ollama_setportforjob / ollama_getport round-trip'
+    ELSE 'FAIL: ollama_setportforjob / ollama_getport round-trip'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Model
+CALL dbsdk_v1.ollama_setmodelforjob('testmodel:latest');
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_getmodel() = 'testmodel:latest'
+    THEN 'PASS: ollama_setmodelforjob / ollama_getmodel round-trip'
+    ELSE 'FAIL: ollama_setmodelforjob / ollama_getmodel round-trip'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Protocol
+CALL dbsdk_v1.ollama_setprotocolforjob('https');
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_getprotocol() = 'https'
+    THEN 'PASS: ollama_setprotocolforjob / ollama_getprotocol round-trip'
+    ELSE 'FAIL: ollama_setprotocolforjob / ollama_getprotocol round-trip'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Reset job-scope variables so the generate tests use the conf row
+SET dbsdk_v1.ollama_server   = NULL;
+SET dbsdk_v1.ollama_port     = NULL;
+SET dbsdk_v1.ollama_model    = NULL;
+SET dbsdk_v1.ollama_protocol = NULL;
+
+-- ============================================================
+-- Section 2: set*forme persistence (writes to dbsdk_v1.conf)
+-- ============================================================
+
+-- Teardown: remove any existing conf row for test_user
+DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+
+CALL dbsdk_v1.ollama_setserverforme('forme-ollama-host');
+CALL dbsdk_v1.ollama_setportforme(29999);
+CALL dbsdk_v1.ollama_setmodelforme('forme-model:latest');
+CALL dbsdk_v1.ollama_setprotocolforme('http');
+
+SELECT
+  CASE
+    WHEN (SELECT COUNT(*) FROM dbsdk_v1.conf
+          WHERE usrprf         = dbsdk_v1.test_user
+            AND ollama_server   = 'forme-ollama-host'
+            AND ollama_port     = 29999
+            AND ollama_model    = 'forme-model:latest'
+            AND ollama_protocol = 'http') = 1
+    THEN 'PASS: set*forme procedures wrote correct values to dbsdk_v1.conf'
+    ELSE 'FAIL: set*forme procedures did not write expected values to dbsdk_v1.conf'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Teardown: remove the conf row written by set*forme tests
+DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+
+-- ============================================================
+-- Section 3: ollama_generate — live endpoint tests
+-- Uses dbsdk_v1.conf row for test_user (Guard 2 ensures it exists)
+-- ============================================================
+
+-- Test: generate with default model
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_generate('Why is the sky blue?') IS NOT NULL
+    THEN 'PASS: ollama_generate returned a non-null response (default model)'
+    ELSE 'FAIL: ollama_generate returned null (default model)'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Test: generate with explicit model_id
+-- Replace 'granite3.2:8b' with any model available on the test Ollama server
+SELECT
+  CASE
+    WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite3.2:8b') IS NOT NULL
+    THEN 'PASS: ollama_generate returned a non-null response (explicit model_id)'
+    ELSE 'FAIL: ollama_generate returned null (explicit model_id)'
+  END AS test_result
+FROM sysibm.sysdummy1;

--- a/test/ollama_test.sql
+++ b/test/ollama_test.sql
@@ -13,18 +13,17 @@
 
 -- ----------------------------------------
 -- Configurable test user profile name.
--- Edit the SET statement below to change it.
+-- If your test profile is not DBSDKTEST, change the value
+-- in the two places marked <<CHANGE_TEST_USER>> below.
 -- ----------------------------------------
-CREATE OR REPLACE VARIABLE dbsdk_v1.test_user VARCHAR(10) DEFAULT 'DBSDKTEST';
-SET dbsdk_v1.test_user = 'DBSDKTEST';
 
 -- ----------------------------------------
 -- Guard 1: must be run as test_user
 -- ----------------------------------------
 BEGIN
-  IF CURRENT_USER <> dbsdk_v1.test_user THEN
+  IF CURRENT_USER <> 'DBSDKTEST' THEN  -- <<CHANGE_TEST_USER>>
     SIGNAL SQLSTATE '45000'
-      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit dbsdk_v1.test_user to change)';
+      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit the CHANGE_TEST_USER lines to change)';
   END IF;
 END;
 
@@ -38,7 +37,7 @@ END;
 BEGIN
   IF dbsdk_v1.ollama_getserver() IS NULL THEN
     SIGNAL SQLSTATE '45001'
-      SET MESSAGE_TEXT = 'Ollama server not configured for test_user — add a conf row for DBSDKTEST and retry';
+      SET MESSAGE_TEXT = 'Ollama server not configured for test_user - add a conf row for DBSDKTEST and retry';
   END IF;
 END;
 
@@ -87,17 +86,17 @@ SELECT
 FROM sysibm.sysdummy1;
 
 -- Reset job-scope variables so the generate tests use the conf row
-SET dbsdk_v1.ollama_server   = NULL;
-SET dbsdk_v1.ollama_port     = NULL;
-SET dbsdk_v1.ollama_model    = NULL;
-SET dbsdk_v1.ollama_protocol = NULL;
+CALL dbsdk_v1.ollama_setserverforjob(NULL);
+CALL dbsdk_v1.ollama_setportforjob(NULL);
+CALL dbsdk_v1.ollama_setmodelforjob(NULL);
+CALL dbsdk_v1.ollama_setprotocolforjob(NULL);
 
 -- ============================================================
 -- Section 2: set*forme persistence (writes to dbsdk_v1.conf)
 -- ============================================================
 
 -- Teardown: remove any existing conf row for test_user
-DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';  -- <<CHANGE_TEST_USER>>
 
 CALL dbsdk_v1.ollama_setserverforme('forme-ollama-host');
 CALL dbsdk_v1.ollama_setportforme(29999);
@@ -107,7 +106,7 @@ CALL dbsdk_v1.ollama_setprotocolforme('http');
 SELECT
   CASE
     WHEN (SELECT COUNT(*) FROM dbsdk_v1.conf
-          WHERE usrprf         = dbsdk_v1.test_user
+            WHERE usrprf         = 'DBSDKTEST'  -- <<CHANGE_TEST_USER>>
             AND ollama_server   = 'forme-ollama-host'
             AND ollama_port     = 29999
             AND ollama_model    = 'forme-model:latest'
@@ -118,11 +117,19 @@ SELECT
 FROM sysibm.sysdummy1;
 
 -- Teardown: remove the conf row written by set*forme tests
-DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';  -- <<CHANGE_TEST_USER>>
+
+-- Section 3 uses job-scope variables set directly via set*forjob calls
+-- so it does not depend on the conf row that Section 2 deleted.
+-- Edit these values to match your real Ollama server and default model.
+CALL dbsdk_v1.ollama_setserverforjob('localhost');    -- <<CHANGE IF NEEDED>>
+CALL dbsdk_v1.ollama_setportforjob(11434);            -- <<CHANGE IF NEEDED>>
+CALL dbsdk_v1.ollama_setprotocolforjob('http');       -- <<CHANGE IF NEEDED>>
+CALL dbsdk_v1.ollama_setmodelforjob('granite4.1:8b'); -- <<CHANGE IF NEEDED>>
 
 -- ============================================================
 -- Section 3: ollama_generate — live endpoint tests
--- Uses dbsdk_v1.conf row for test_user (Guard 2 ensures it exists)
+-- Uses job-scope variables set immediately above.
 -- ============================================================
 
 -- Test: generate with default model
@@ -138,7 +145,7 @@ FROM sysibm.sysdummy1;
 -- Replace 'granite3.2:8b' with any model available on the test Ollama server
 SELECT
   CASE
-    WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite3.2:8b') IS NOT NULL
+    WHEN dbsdk_v1.ollama_generate('What is 2 + 2?', 'granite4.1:8b') IS NOT NULL
     THEN 'PASS: ollama_generate returned a non-null response (explicit model_id)'
     ELSE 'FAIL: ollama_generate returned null (explicit model_id)'
   END AS test_result

--- a/test/openai_compatible_chat_generate_test.sql
+++ b/test/openai_compatible_chat_generate_test.sql
@@ -1,4 +1,4 @@
--- ============================================================
+﻿-- ============================================================
 -- Test script for openai_compatible_chat_generate
 -- and openai_compatible set*forme persistence
 -- ============================================================
@@ -22,18 +22,17 @@
 
 -- ----------------------------------------
 -- Configurable test user profile name.
--- Edit the SET statement below to change it.
+-- If your test profile is not DBSDKTEST, change the value
+-- in the places marked <<CHANGE_TEST_USER>> below.
 -- ----------------------------------------
-CREATE OR REPLACE VARIABLE dbsdk_v1.test_user VARCHAR(10) DEFAULT 'DBSDKTEST';
-SET dbsdk_v1.test_user = 'DBSDKTEST';
 
 -- ----------------------------------------
 -- Guard 1: must be run as test_user
 -- ----------------------------------------
 BEGIN
-  IF CURRENT_USER <> dbsdk_v1.test_user THEN
+  IF CURRENT_USER <> 'DBSDKTEST' THEN  -- <<CHANGE_TEST_USER>>
     SIGNAL SQLSTATE '45000'
-      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit dbsdk_v1.test_user to change)';
+      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit the CHANGE_TEST_USER lines to change)';
   END IF;
 END;
 
@@ -56,7 +55,7 @@ BEGIN
   IF dbsdk_v1.openai_compatible_getserver() IS NULL
   OR dbsdk_v1.openai_compatible_getmodel()  IS NULL THEN
     SIGNAL SQLSTATE '45001'
-      SET MESSAGE_TEXT = 'LOCAL endpoint not configured — skipping local chat_generate tests';
+      SET MESSAGE_TEXT = 'LOCAL endpoint not configured - skipping local chat_generate tests';
   END IF;
 END;
 
@@ -111,12 +110,12 @@ SELECT
 FROM sysibm.sysdummy1;
 
 -- Reset local job-scope variables
-SET dbsdk_v1.openai_compatible_server   = NULL;
-SET dbsdk_v1.openai_compatible_port     = NULL;
-SET dbsdk_v1.openai_compatible_protocol = NULL;
-SET dbsdk_v1.openai_compatible_basepath = NULL;
-SET dbsdk_v1.openai_compatible_model    = NULL;
-SET dbsdk_v1.openai_compatible_apikey   = NULL;
+CALL dbsdk_v1.openai_compatible_setserverforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setportforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setbasepathforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setmodelforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setapikeyforjob(NULL);
 
 -- ============================================================
 -- CLOUD ENDPOINT SUB-BLOCK
@@ -127,11 +126,11 @@ SET dbsdk_v1.openai_compatible_apikey   = NULL;
 
 -- Set job-scope variables for cloud endpoint
 -- Replace these values with real cloud endpoint details before running
-CALL dbsdk_v1.openai_compatible_setserverforjob('api.openai.com');
+CALL dbsdk_v1.openai_compatible_setserverforjob('generativelanguage.googleapis.com');
 CALL dbsdk_v1.openai_compatible_setportforjob(443);
 CALL dbsdk_v1.openai_compatible_setprotocolforjob('https');
-CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1');
-CALL dbsdk_v1.openai_compatible_setmodelforjob('gpt-3.5-turbo');
+CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1beta/openai');
+CALL dbsdk_v1.openai_compatible_setmodelforjob('gemini-3.6-flash');
 -- Set your API key here before running:
 CALL dbsdk_v1.openai_compatible_setapikeyforjob(NULL);
 
@@ -139,7 +138,7 @@ CALL dbsdk_v1.openai_compatible_setapikeyforjob(NULL);
 BEGIN
   IF dbsdk_v1.openai_compatible_getapikey() IS NULL THEN
     SIGNAL SQLSTATE '45002'
-      SET MESSAGE_TEXT = 'CLOUD endpoint not configured — set API key via openai_compatible_setapikeyforjob and retry';
+      SET MESSAGE_TEXT = 'CLOUD endpoint not configured - set API key via openai_compatible_setapikeyforjob and retry';
   END IF;
 END;
 
@@ -169,12 +168,12 @@ SELECT
 FROM sysibm.sysdummy1;
 
 -- Reset cloud job-scope variables
-SET dbsdk_v1.openai_compatible_server   = NULL;
-SET dbsdk_v1.openai_compatible_port     = NULL;
-SET dbsdk_v1.openai_compatible_protocol = NULL;
-SET dbsdk_v1.openai_compatible_basepath = NULL;
-SET dbsdk_v1.openai_compatible_model    = NULL;
-SET dbsdk_v1.openai_compatible_apikey   = NULL;
+CALL dbsdk_v1.openai_compatible_setserverforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setportforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setbasepathforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setmodelforjob(NULL);
+CALL dbsdk_v1.openai_compatible_setapikeyforjob(NULL);
 
 -- ============================================================
 -- set*forme PERSISTENCE TESTS
@@ -183,7 +182,7 @@ SET dbsdk_v1.openai_compatible_apikey   = NULL;
 -- ============================================================
 
 -- Teardown: remove any existing conf row for test_user
-DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';  -- <<CHANGE_TEST_USER>>
 
 CALL dbsdk_v1.openai_compatible_setapikeyforme('test-api-key-forme');
 CALL dbsdk_v1.openai_compatible_setmodelforme('forme-model-id');
@@ -192,7 +191,7 @@ CALL dbsdk_v1.openai_compatible_setbasepathforme('/forme/v1');
 SELECT
   CASE
     WHEN (SELECT COUNT(*) FROM dbsdk_v1.conf
-          WHERE usrprf                      = dbsdk_v1.test_user
+          WHERE usrprf                      = 'DBSDKTEST'  -- <<CHANGE_TEST_USER>>
             AND openai_compatible_apikey    = 'test-api-key-forme'
             AND openai_compatible_model     = 'forme-model-id'
             AND openai_compatible_basepath  = '/forme/v1') = 1
@@ -202,4 +201,4 @@ SELECT
 FROM sysibm.sysdummy1;
 
 -- Teardown: remove the conf row written by set*forme tests
-DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+DELETE FROM dbsdk_v1.conf WHERE usrprf = 'DBSDKTEST';  -- <<CHANGE_TEST_USER>>

--- a/test/openai_compatible_chat_generate_test.sql
+++ b/test/openai_compatible_chat_generate_test.sql
@@ -1,0 +1,205 @@
+-- ============================================================
+-- Test script for openai_compatible_chat_generate
+-- and openai_compatible set*forme persistence
+-- ============================================================
+-- Covers:
+--   LOCAL sub-block:
+--     - openai_compatible_chat_generate() default options
+--     - openai_compatible_chat_generate() with temperature option
+--     - openai_compatible_chat_generate() with max_tokens option
+--     - openai_compatible_chat_generate() with base_url direct override
+--   CLOUD sub-block:
+--     - openai_compatible_chat_generate() default options (with apikey)
+--     - openai_compatible_chat_generate() with inline api_key_ parameter
+--   set*forme persistence (always runs):
+--     - openai_compatible_setapikeyforme
+--     - openai_compatible_setmodelforme
+--     - openai_compatible_setbasepathforme
+--
+-- Run as: the user profile named in dbsdk_v1.test_user (default: DBSDKTEST)
+-- Compatible with: ACS Run SQL Scripts, RUNSQLSTM / runsql.sh
+-- ============================================================
+
+-- ----------------------------------------
+-- Configurable test user profile name.
+-- Edit the SET statement below to change it.
+-- ----------------------------------------
+CREATE OR REPLACE VARIABLE dbsdk_v1.test_user VARCHAR(10) DEFAULT 'DBSDKTEST';
+SET dbsdk_v1.test_user = 'DBSDKTEST';
+
+-- ----------------------------------------
+-- Guard 1: must be run as test_user
+-- ----------------------------------------
+BEGIN
+  IF CURRENT_USER <> dbsdk_v1.test_user THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Must be run as DBSDKTEST (edit dbsdk_v1.test_user to change)';
+  END IF;
+END;
+
+-- ============================================================
+-- LOCAL ENDPOINT SUB-BLOCK
+-- Configure the variables below for your local OpenAI-compatible
+-- server (e.g. llama.cpp, LM Studio, Ollama with OpenAI shim).
+-- If no local server is available, this block will skip cleanly.
+-- ============================================================
+
+-- Set job-scope variables for local endpoint (no API key needed)
+CALL dbsdk_v1.openai_compatible_setserverforjob('localhost');
+CALL dbsdk_v1.openai_compatible_setportforjob(8080);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob('http');
+CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1');
+CALL dbsdk_v1.openai_compatible_setmodelforjob('llama3');
+
+-- Guard: skip local block if server or model is not configured
+BEGIN
+  IF dbsdk_v1.openai_compatible_getserver() IS NULL
+  OR dbsdk_v1.openai_compatible_getmodel()  IS NULL THEN
+    SIGNAL SQLSTATE '45001'
+      SET MESSAGE_TEXT = 'LOCAL endpoint not configured — skipping local chat_generate tests';
+  END IF;
+END;
+
+-- Test: chat_generate default options (local)
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'Why is the sky blue?'
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate default options (local)'
+    ELSE 'FAIL: openai_compatible_chat_generate default options (local) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Test: chat_generate with temperature option (local)
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'Name three planets.',
+           '{"temperature": 0.5}'
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate with temperature option (local)'
+    ELSE 'FAIL: openai_compatible_chat_generate with temperature option (local) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Test: chat_generate with max_tokens option (local)
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'Count from 1 to 5.',
+           '{"max_tokens": 50}'
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate with max_tokens option (local)'
+    ELSE 'FAIL: openai_compatible_chat_generate with max_tokens option (local) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Test: chat_generate with base_url direct override (local)
+-- This exercises the base_url parameter path in the function body.
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'What is 2 + 2?',
+           '{}',
+           NULL,
+           'http://localhost:8080/v1'
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate with base_url override (local)'
+    ELSE 'FAIL: openai_compatible_chat_generate with base_url override (local) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Reset local job-scope variables
+SET dbsdk_v1.openai_compatible_server   = NULL;
+SET dbsdk_v1.openai_compatible_port     = NULL;
+SET dbsdk_v1.openai_compatible_protocol = NULL;
+SET dbsdk_v1.openai_compatible_basepath = NULL;
+SET dbsdk_v1.openai_compatible_model    = NULL;
+SET dbsdk_v1.openai_compatible_apikey   = NULL;
+
+-- ============================================================
+-- CLOUD ENDPOINT SUB-BLOCK
+-- Configure the variables below for a cloud OpenAI-compatible
+-- endpoint (e.g. OpenAI api.openai.com, Gemini, etc.).
+-- An API key is required. If not configured, this block skips.
+-- ============================================================
+
+-- Set job-scope variables for cloud endpoint
+-- Replace these values with real cloud endpoint details before running
+CALL dbsdk_v1.openai_compatible_setserverforjob('api.openai.com');
+CALL dbsdk_v1.openai_compatible_setportforjob(443);
+CALL dbsdk_v1.openai_compatible_setprotocolforjob('https');
+CALL dbsdk_v1.openai_compatible_setbasepathforjob('/v1');
+CALL dbsdk_v1.openai_compatible_setmodelforjob('gpt-3.5-turbo');
+-- Set your API key here before running:
+CALL dbsdk_v1.openai_compatible_setapikeyforjob(NULL);
+
+-- Guard: skip cloud block if API key is not configured
+BEGIN
+  IF dbsdk_v1.openai_compatible_getapikey() IS NULL THEN
+    SIGNAL SQLSTATE '45002'
+      SET MESSAGE_TEXT = 'CLOUD endpoint not configured — set API key via openai_compatible_setapikeyforjob and retry';
+  END IF;
+END;
+
+-- Test: chat_generate default options (cloud)
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'Why is the sky blue?'
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate default options (cloud)'
+    ELSE 'FAIL: openai_compatible_chat_generate default options (cloud) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Test: chat_generate with inline api_key_ parameter override
+-- This exercises the api_key_ parameter path in the function body.
+SELECT
+  CASE
+    WHEN dbsdk_v1.openai_compatible_chat_generate(
+           'What is 2 + 2?',
+           '{}',
+           dbsdk_v1.openai_compatible_getapikey()
+         ) IS NOT NULL
+    THEN 'PASS: openai_compatible_chat_generate with inline api_key_ override (cloud)'
+    ELSE 'FAIL: openai_compatible_chat_generate with inline api_key_ override (cloud) returned null'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Reset cloud job-scope variables
+SET dbsdk_v1.openai_compatible_server   = NULL;
+SET dbsdk_v1.openai_compatible_port     = NULL;
+SET dbsdk_v1.openai_compatible_protocol = NULL;
+SET dbsdk_v1.openai_compatible_basepath = NULL;
+SET dbsdk_v1.openai_compatible_model    = NULL;
+SET dbsdk_v1.openai_compatible_apikey   = NULL;
+
+-- ============================================================
+-- set*forme PERSISTENCE TESTS
+-- These tests always run (independent of local/cloud guards).
+-- They write to dbsdk_v1.conf and clean up after themselves.
+-- ============================================================
+
+-- Teardown: remove any existing conf row for test_user
+DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;
+
+CALL dbsdk_v1.openai_compatible_setapikeyforme('test-api-key-forme');
+CALL dbsdk_v1.openai_compatible_setmodelforme('forme-model-id');
+CALL dbsdk_v1.openai_compatible_setbasepathforme('/forme/v1');
+
+SELECT
+  CASE
+    WHEN (SELECT COUNT(*) FROM dbsdk_v1.conf
+          WHERE usrprf                      = dbsdk_v1.test_user
+            AND openai_compatible_apikey    = 'test-api-key-forme'
+            AND openai_compatible_model     = 'forme-model-id'
+            AND openai_compatible_basepath  = '/forme/v1') = 1
+    THEN 'PASS: set*forme procedures wrote correct values to dbsdk_v1.conf'
+    ELSE 'FAIL: set*forme procedures did not write expected values to dbsdk_v1.conf'
+  END AS test_result
+FROM sysibm.sysdummy1;
+
+-- Teardown: remove the conf row written by set*forme tests
+DELETE FROM dbsdk_v1.conf WHERE usrprf = dbsdk_v1.test_user;


### PR DESCRIPTION
- Fix: `set*forme` procedure in both `src/ollama/utils.sql` and `src/openai_compatible/utils.sql` used `CURRENT_USER` in their `MERGE` statement, but neither had `set option usrprf = *user`  so they compiled as `*OWNER` adoption, meaning `CURRENT_USER` inside the procedure resolved to the schema owner, not the calling user.
- Add 2 new test SQLs:
  - `test/ollama_test.sql`
  - `test/openai_compatible_chat_generate_test.sql`