### PR TITLE
Admin Screen display files no longer uppercase api keys and tokens

### DIFF
--- a/src/admin/dspf/CFGOPENAID.dspf
+++ b/src/admin/dspf/CFGOPENAID.dspf
@@ -54,13 +54,15 @@
      A                                  9  2'Model:'
      A            OAMODEL       50A  B  9 20CHECK(LC)
      A                                 11  2'API Key:'
-     A            OAAPIKEY      50A  B 11 20DSPATR(ND UL)
+     A            OAAPIKEY      50A  B 11 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                 11 72'(1/2)'
      A                                      COLOR(BLU)
      A                                 12 20'^ Starts here'
      A                                      COLOR(BLU)
-     A            OAAPIKY2      50A  B 13 20DSPATR(ND UL)
+     A            OAAPIKY2      50A  B 13 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                 13 72'(2/2)'
      A                                      COLOR(BLU)

--- a/src/admin/dspf/CFGSLACKD.dspf
+++ b/src/admin/dspf/CFGSLACKD.dspf
@@ -41,13 +41,15 @@
      A* Configuration Fields
      A*=====================================================================
      A                                  6  2'Webhook URL:'
-     A            SLWEBHOK      50A  B  6 20DSPATR(ND UL)
+     A            SLWEBHOK      50A  B  6 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                  6 72'(1/2)'
      A                                      COLOR(BLU)
      A                                  7 20'^ Starts here'
      A                                      COLOR(BLU)
-     A            SLWEBHK2      50A  B  8 20DSPATR(ND UL)
+     A            SLWEBHK2      50A  B  8 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                  8 72'(2/2)'
      A                                      COLOR(BLU)

--- a/src/admin/dspf/CFGTWILIOD.dspf
+++ b/src/admin/dspf/CFGTWILIOD.dspf
@@ -55,13 +55,15 @@
      A                                 12 72'(2/2)'
      A                                      COLOR(BLU)
      A                                 14  2'Auth Token:'
-     A            TWAUTHTN      50A  B 14 20DSPATR(ND UL)
+     A            TWAUTHTN      50A  B 14 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                 14 72'(1/2)'
      A                                      COLOR(BLU)
      A                                 15 20'^ Starts here'
      A                                      COLOR(BLU)
-     A            TWAUTHK2      50A  B 16 20DSPATR(ND UL)
+     A            TWAUTHK2      50A  B 16 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                 16 72'(2/2)'
      A                                      COLOR(BLU)

--- a/src/admin/dspf/CFGWXD.dspf
+++ b/src/admin/dspf/CFGWXD.dspf
@@ -49,7 +49,8 @@
      A                                  8 32'(e.g., 2023-07-07)'
      A                                      COLOR(BLU)
      A                                 10  2'API Key:'
-     A            WXAPIKEY     100A  B 10 20DSPATR(ND UL)
+     A            WXAPIKEY     100A  B 10 20CHECK(LC)
+     A                                      DSPATR(ND UL)
      A                                      COLOR(WHT)
      A                                 10 38'(password protected)'
      A                                      COLOR(BLU)


### PR DESCRIPTION
Display files were uppercasing API keys and tokens entered in the Admin Screens. Now fixed.